### PR TITLE
Extend to group members and management

### DIFF
--- a/checkbans.js
+++ b/checkbans.js
@@ -45,7 +45,7 @@ javascript:(function(){
         return add(steam64identifier, miniProfileId);
     }
 
-    var friends = [].slice.call(document.querySelectorAll('#memberList .member_block, .friendHolder, .friendBlock'));
+    var friends = [].slice.call(document.querySelectorAll('#memberList .member_block, #memberManageList .member_block, .friendHolder, .friendBlock'));
     var lookup = {};
 
     friends.forEach(function(friend) {


### PR DESCRIPTION
Allows easy review of banned players in any group. Helps group admins quickly scan for and manage banned players within their groups.
