### PR TITLE
Extends to group members and management

### DIFF
--- a/checkbans.js
+++ b/checkbans.js
@@ -45,7 +45,7 @@ javascript:(function(){
         return add(steam64identifier, miniProfileId);
     }
 
-    var friends = [].slice.call(document.querySelectorAll('#memberList .member_block, .friendHolder, .friendBlock'));
+    var friends = [].slice.call(document.querySelectorAll('#memberList .member_block, #memberManageList .member_block, .friendHolder, .friendBlock'));
     var lookup = {};
 
     friends.forEach(function(friend) {

--- a/checkbans.js
+++ b/checkbans.js
@@ -45,7 +45,7 @@ javascript:(function(){
         return add(steam64identifier, miniProfileId);
     }
 
-    var friends = [].slice.call(document.querySelectorAll('#memberList .member_block, #memberManageList .member_block, .friendHolder, .friendBlock'));
+    var friends = [].slice.call(document.querySelectorAll('#memberList .member_block, #memberManageList .member_block, .friendHolder, .friendBlock '));
     var lookup = {};
 
     friends.forEach(function(friend) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Ban Checker for Steam",
-  "description": "Automatically check bans of people you recently played with (or your friends)",
-  "version": "0.4",
+  "description": "Automatically check bans of people you recently played with, your friends, and group members.",
+  "version": "0.5",
   "icons": { "16": "ow16.png",
 			"48": "ow48.png",
 			"128": "ow128.png" },
@@ -14,7 +14,7 @@
   "content_scripts": [ {
     "js": [ "checkbans.min.js" ],
 	"run_at": "document_end",
-    "matches": [ "*://steamcommunity.com/id/*/friends*", "*://steamcommunity.com/profiles/*/friends*" ]
+    "matches": [ "*://steamcommunity.com/id/*/friends*", "*://steamcommunity.com/profiles/*/friends*", "*://steamcommunity.com/groups/*/members", "*://steamcommunity.com/groups/*/membersManage" ]
   }],
   "manifest_version": 2
 }


### PR DESCRIPTION
Allows easy review of banned players in any group. Helps group admins quickly scan for and manage banned players within their groups. This further helps players grow aware of those they associate with through Steam Community Groups. 
