### PR TITLE
Patch 3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,129 +1,20 @@
-javascript:(function(){
-    // Javascript does not work well with integers greater than 53 bits precision... So we need
-    // to do our maths using strings.
-    function getDigit(x, digitIndex) {
-        return (digitIndex >= x.length) ? "0" : x.charAt(x.length - digitIndex - 1);
-    }
-    function prefixZeros(strint, zeroCount) {
-        var result = strint;
-        for (var i = 0; i < zeroCount; i++) {
-            result = "0" + result;
-        }
-        return result;
-    }
-    //Only works for positive numbers, which is fine in our use case.
-    function add(x, y) {
-        var maxLength = Math.max(x.length, y.length);
-        var result = "";
-        var borrow = 0;
-        var leadingZeros = 0;
-        for (var i = 0; i < maxLength; i++) {
-            var lhs = Number(getDigit(x, i));
-            var rhs = Number(getDigit(y, i));
-            var digit = lhs + rhs + borrow;
-            borrow = 0;
-            while (digit >= 10) {
-                digit -= 10;
-                borrow++;
-            }
-            if (digit === 0) {
-                leadingZeros++;
-            } else {
-                result = String(digit) + prefixZeros(result, leadingZeros);
-                leadingZeros = 0;
-            }
-        }
-        if (borrow > 0) {
-            result = String(borrow) + result;
-        }
-        return result;
-    }
-
-    function getId(friend) {
-        var steam64identifier = "76561197960265728";
-        var miniProfileId = friend.attributes.getNamedItem('data-miniprofile').value;
-        return add(steam64identifier, miniProfileId);
-    }
-
-    var friends = [].slice.call(document.querySelectorAll('#memberList .member_block, #memberManageList .member_block, .friendHolder, .friendBlock '));
-    var lookup = {};
-
-    friends.forEach(function(friend) {
-        var id = getId(friend);
-        if (!lookup[id]) {
-            lookup[id] = [];
-        }
-        lookup[id].push(friend);
-    });
-
-    function setVacation(player) {
-        var friendElements = lookup[player.SteamId];
-
-        friendElements.forEach(function(friend) {
-            var inGameText = friend.querySelector('.linkFriend_in-game');
-            var span = document.createElement('span');
-            span.style.fontWeight = 'bold';
-            span.style.display = 'block';
-
-            if (inGameText) {
-                inGameText.innerHTML = inGameText.innerHTML.replace(/<br ?\/?>/, ' - ');
-            }
-
-            if (player.NumberOfVACBans || player.NumberOfGameBans) {
-                var text = '';
-
-                if (player.NumberOfGameBans) {
-                    text += player.NumberOfGameBans + ' OW bans';
-                }
-
-                if (player.NumberOfVACBans) {
-                    text += (text === '' ? '' : ', ') +
-                        player.NumberOfVACBans + ' VAC bans';
-                }
-                text += ' ' + player.DaysSinceLastBan + ' days ago.';
-
-                span.style.color = 'rgb(255, 73, 73)';
-                span.innerHTML = text;
-            } else {
-                span.style.color = 'rgb(43, 203, 64)';
-                span.innerHTML = 'No Bans for this player.';
-            }
-
-            friend.querySelector('.friendSmallText').appendChild(span);
-        });
-    }
-
-    function onData(xmlHttp) {
-        if (xmlHttp.readyState === XMLHttpRequest.DONE && xmlHttp.status === 200) {
-            var data = JSON.parse(xmlHttp.responseText);
-            data.players.forEach(setVacation);
-        }
-    }
-
-    function makeApiCall(ids, apikey) {
-        var xmlHttp = new XMLHttpRequest();
-        //API only allows 100 steam ids at once.
-        var endpointRoot = 'https://api.steampowered.com/ISteamUser/GetPlayerBans/v1/?key='+apikey+'&steamids=';
-        var endpoint = endpointRoot + ids.join(',');
-
-        xmlHttp.onreadystatechange = function() { onData(xmlHttp); };
-        xmlHttp.open('GET', endpoint, true);
-        xmlHttp.send();
-    }
-
-	var defaultkeys = ["5DA40A4A4699DEE30C1C9A7BCE84C914",
-						"5970533AA2A0651E9105E706D0F8EDDC",
-						"2B3382EBA9E8C1B58054BD5C5EE1C36A"];
-	chrome.storage.sync.get("customapikey", function(data) {
-		if (typeof data['customapikey'] == 'undefined'){
-			var apikey = defaultkeys[Math.floor(Math.random() * 3)];
-		}else{
-			var apikey = data['customapikey'];
-		}
-		var ids = Object.keys(lookup);
-		while (ids.length > 0) {
-			var batch = ids.splice(0, 100);
-			makeApiCall(batch, apikey);
-		}
-	});  
-})();
+{
+  "name": "Ban Checker for Steam",
+  "description": "Automatically check bans of people you recently played with, your friends, and group members.",
+  "version": "0.5",
+  "icons": { "16": "ow16.png",
+			"48": "ow48.png",
+			"128": "ow128.png" },
+  "permissions": [
+    "storage", "*://steamcommunity.com/*", "https://api.steampowered.com/*"
+  ],
+  "options_ui": {
+    "page": "setkey.html",
+    "chrome_style": true },
+  "content_scripts": [ {
+    "js": [ "checkbans.min.js" ],
+	"run_at": "document_end",
+    "matches": [ "*://steamcommunity.com/id/*/friends*", "*://steamcommunity.com/profiles/*/friends*", "*://steamcommunity.com/groups/*members*", "*://steamcommunity.com/groups/*/membersManage*" ]
+  }],
+  "manifest_version": 2
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,20 +1,129 @@
-{
-  "name": "Ban Checker for Steam",
-  "description": "Automatically check bans of people you recently played with, your friends, and group members.",
-  "version": "0.5",
-  "icons": { "16": "ow16.png",
-			"48": "ow48.png",
-			"128": "ow128.png" },
-  "permissions": [
-    "storage", "*://steamcommunity.com/*", "https://api.steampowered.com/*"
-  ],
-  "options_ui": {
-    "page": "setkey.html",
-    "chrome_style": true },
-  "content_scripts": [ {
-    "js": [ "checkbans.min.js" ],
-	"run_at": "document_end",
-    "matches": [ "*://steamcommunity.com/id/*/friends*", "*://steamcommunity.com/profiles/*/friends*", "*://steamcommunity.com/groups/*/members", "*://steamcommunity.com/groups/*/membersManage" ]
-  }],
-  "manifest_version": 2
-}
+javascript:(function(){
+    // Javascript does not work well with integers greater than 53 bits precision... So we need
+    // to do our maths using strings.
+    function getDigit(x, digitIndex) {
+        return (digitIndex >= x.length) ? "0" : x.charAt(x.length - digitIndex - 1);
+    }
+    function prefixZeros(strint, zeroCount) {
+        var result = strint;
+        for (var i = 0; i < zeroCount; i++) {
+            result = "0" + result;
+        }
+        return result;
+    }
+    //Only works for positive numbers, which is fine in our use case.
+    function add(x, y) {
+        var maxLength = Math.max(x.length, y.length);
+        var result = "";
+        var borrow = 0;
+        var leadingZeros = 0;
+        for (var i = 0; i < maxLength; i++) {
+            var lhs = Number(getDigit(x, i));
+            var rhs = Number(getDigit(y, i));
+            var digit = lhs + rhs + borrow;
+            borrow = 0;
+            while (digit >= 10) {
+                digit -= 10;
+                borrow++;
+            }
+            if (digit === 0) {
+                leadingZeros++;
+            } else {
+                result = String(digit) + prefixZeros(result, leadingZeros);
+                leadingZeros = 0;
+            }
+        }
+        if (borrow > 0) {
+            result = String(borrow) + result;
+        }
+        return result;
+    }
+
+    function getId(friend) {
+        var steam64identifier = "76561197960265728";
+        var miniProfileId = friend.attributes.getNamedItem('data-miniprofile').value;
+        return add(steam64identifier, miniProfileId);
+    }
+
+    var friends = [].slice.call(document.querySelectorAll('#memberList .member_block, #memberManageList .member_block, .friendHolder, .friendBlock '));
+    var lookup = {};
+
+    friends.forEach(function(friend) {
+        var id = getId(friend);
+        if (!lookup[id]) {
+            lookup[id] = [];
+        }
+        lookup[id].push(friend);
+    });
+
+    function setVacation(player) {
+        var friendElements = lookup[player.SteamId];
+
+        friendElements.forEach(function(friend) {
+            var inGameText = friend.querySelector('.linkFriend_in-game');
+            var span = document.createElement('span');
+            span.style.fontWeight = 'bold';
+            span.style.display = 'block';
+
+            if (inGameText) {
+                inGameText.innerHTML = inGameText.innerHTML.replace(/<br ?\/?>/, ' - ');
+            }
+
+            if (player.NumberOfVACBans || player.NumberOfGameBans) {
+                var text = '';
+
+                if (player.NumberOfGameBans) {
+                    text += player.NumberOfGameBans + ' OW bans';
+                }
+
+                if (player.NumberOfVACBans) {
+                    text += (text === '' ? '' : ', ') +
+                        player.NumberOfVACBans + ' VAC bans';
+                }
+                text += ' ' + player.DaysSinceLastBan + ' days ago.';
+
+                span.style.color = 'rgb(255, 73, 73)';
+                span.innerHTML = text;
+            } else {
+                span.style.color = 'rgb(43, 203, 64)';
+                span.innerHTML = 'No Bans for this player.';
+            }
+
+            friend.querySelector('.friendSmallText').appendChild(span);
+        });
+    }
+
+    function onData(xmlHttp) {
+        if (xmlHttp.readyState === XMLHttpRequest.DONE && xmlHttp.status === 200) {
+            var data = JSON.parse(xmlHttp.responseText);
+            data.players.forEach(setVacation);
+        }
+    }
+
+    function makeApiCall(ids, apikey) {
+        var xmlHttp = new XMLHttpRequest();
+        //API only allows 100 steam ids at once.
+        var endpointRoot = 'https://api.steampowered.com/ISteamUser/GetPlayerBans/v1/?key='+apikey+'&steamids=';
+        var endpoint = endpointRoot + ids.join(',');
+
+        xmlHttp.onreadystatechange = function() { onData(xmlHttp); };
+        xmlHttp.open('GET', endpoint, true);
+        xmlHttp.send();
+    }
+
+	var defaultkeys = ["5DA40A4A4699DEE30C1C9A7BCE84C914",
+						"5970533AA2A0651E9105E706D0F8EDDC",
+						"2B3382EBA9E8C1B58054BD5C5EE1C36A"];
+	chrome.storage.sync.get("customapikey", function(data) {
+		if (typeof data['customapikey'] == 'undefined'){
+			var apikey = defaultkeys[Math.floor(Math.random() * 3)];
+		}else{
+			var apikey = data['customapikey'];
+		}
+		var ids = Object.keys(lookup);
+		while (ids.length > 0) {
+			var batch = ids.splice(0, 100);
+			makeApiCall(batch, apikey);
+		}
+	});  
+})();


### PR DESCRIPTION
When tested, I realized the Chrome extension was only matching the first page of group members lists and only when opened as /members (not #members). These edits should now match all group member lists. Thanks and sorry for missing that!
