### PR TITLE
Removed redundant matching for management pages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   "content_scripts": [ {
     "js": [ "checkbans.min.js" ],
 	"run_at": "document_end",
-    "matches": [ "*://steamcommunity.com/id/*/friends*", "*://steamcommunity.com/profiles/*/friends*", "*://steamcommunity.com/groups/*members*", "*://steamcommunity.com/groups/*/membersManage*" ]
+    "matches": [ "*://steamcommunity.com/id/*/friends*", "*://steamcommunity.com/profiles/*/friends*", "*://steamcommunity.com/groups/*members*" ]
   }],
   "manifest_version": 2
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Ban Checker for Steam",
   "description": "Automatically check bans of people you recently played with, your friends, and group members.",
-  "version": "0.5",
+  "version": "0.6",
   "icons": { "16": "ow16.png",
 			"48": "ow48.png",
 			"128": "ow128.png" },
@@ -14,7 +14,13 @@
   "content_scripts": [ {
     "js": [ "checkbans.min.js" ],
 	"run_at": "document_end",
-    "matches": [ "*://steamcommunity.com/id/*/friends*", "*://steamcommunity.com/profiles/*/friends*", "*://steamcommunity.com/groups/*members*" ]
+    "matches": [ "*://steamcommunity.com/id/*/friends*", "*://steamcommunity.com/profiles/*/friends*", "*://steamcommunity.com/groups/*/members*" ]
+  }],
+  "content_scripts": [ {
+    "js": [ "checkbans.min.js" ],
+	"run_at": "document_end",
+    "matches": [ "*://steamcommunity.com/groups/*" ],
+    "include_globs": [ "members" ]
   }],
   "manifest_version": 2
 }


### PR DESCRIPTION
Should still match both #members, /members, and /membersManage
