### PR TITLE
Add context menu links

### DIFF
--- a/contextmenus.js
+++ b/contextmenus.js
@@ -1,0 +1,53 @@
+var context_api, tabs_api;
+if (chrome) {
+  context_api = chrome.contextMenus;
+  tabs_api = chrome.tabs;
+} else if (browser) {
+  context_api = browser.menus;
+  tabs_api = browser.tabs;
+} else {
+  throw new Error('Could not find browser extension sdk');
+}
+
+const actions = {
+  'csgo-matches': 'https://steamcommunity.com/my/gcpd/730?tab=matchhistorycompetitive',
+  'community-friends': 'https://steamcommunity.com/my/friends/',
+  'community-groups': 'https://steamcommunity.com/my/groups/',
+  'github': 'https://github.com/ge-ku/Ban-Checker-for-Steam'
+};
+const context_listener = (info, tab) => {
+  if (info.menuItemId in actions) {
+    tabs_api.create({'url':actions[info.menuItemId]});
+  }
+};
+const context_defs = [
+  {
+    id: 'csgo-matches',
+    type: 'normal',
+    title: 'Csgo match history'
+  },
+  {
+    id: 'community-friends',
+    type: 'normal',
+    title: 'Steam friends'
+  },
+  {
+    id: 'community-groups',
+    type: 'normal',
+    title: 'Steam groups'
+  },
+  {
+    id: 'separator-1',
+    type: 'separator'
+  },
+  {
+    id: 'github',
+    type: 'normal',
+    title: 'Github page'
+  }
+];
+context_defs.forEach((context) => {
+  context['contexts'] = ['browser_action','page_action'];
+  context_api.create(context);
+})
+context_api.onClicked.addListener(context_listener);

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
 			"48": "icons/ow48.png",
 			"128": "icons/ow128.png" },
   "permissions": [
-    "storage", "alarms", "*://steamcommunity.com/*", "https://api.steampowered.com/*"
+    "storage", "alarms", "contextMenus", "*://steamcommunity.com/*", "https://api.steampowered.com/*"
   ],
   "optional_permissions": [
     "notifications"
@@ -38,7 +38,7 @@
     "js": [ "options.js", "gcpd730.js" ],
     "css": [ "display.css" ],
     "run_at": "document_end",
-    "matches": [ 
+    "matches": [
       "*://steamcommunity.com/id/*/gcpd/730/?tab=matchhistorycompetitive",
       "*://steamcommunity.com/profiles/*/gcpd/730/?tab=matchhistorycompetitive",
       "*://steamcommunity.com/id/*/gcpd/730?tab=matchhistorycompetitive",
@@ -47,7 +47,7 @@
   }
   ],
   "background": {
-    "scripts": ["history.js"],
+    "scripts": ["history.js", "contextmenus.js"],
     "persistent": false
   },
   "manifest_version": 2


### PR DESCRIPTION
Adds links in the context menu to pages associated with the extension.
![image](https://user-images.githubusercontent.com/25043847/40618824-9b283a44-628a-11e8-8fd4-cae813a07462.png)
## Testing
- Working on chrome (66.0.3359.181)
- No errors on firefox (60.0.1) however I wasn't able to see the browser action.


