### PR TITLE
Days difference for bans

### DIFF
--- a/gcpd730.js
+++ b/gcpd730.js
@@ -258,9 +258,12 @@ const checkBans = (players) => {
                         playerEl.classList.add('banchecker-checked');
                         verdictEl = playerEl.querySelector('.banchecker-bans');
                         if (verdict) {
+                            let daysAfter = daySinceLastMatch - player.DaysSinceLastBan;
                             if (daySinceLastMatch > player.DaysSinceLastBan) {
+                                verdict += '+' + (daysAfter);
                                 verdictEl.style.color = 'red';
                             } else {
+                                verdict += '-' + (Math.abs(daysAfter));
                                 verdictEl.style.color = 'grey';
                             }
                             verdictEl.style.cursor = 'help';


### PR DESCRIPTION
Added days difference between day played and day banned. This allows to find 'afterBans' by finding 'VAC+'.
![example](https://user-images.githubusercontent.com/3631224/40625633-f6cbc1ee-62b3-11e8-9ba4-84d38f61a9a1.PNG)
